### PR TITLE
Add dashboard API service

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ The application will be available at `http://localhost:3000`
 - `pnpm lint` - Run ESLint
 - `pnpm test` - Run tests
 
+### Backend API (FastAPI)
+
+The backend lives in the `backend/` directory. To run it locally with SQLite:
+
+```bash
+cd backend
+pip install -r requirements.txt
+export DATABASE_URL=sqlite:///erp.db
+uvicorn main:app --reload
+```
+
+Tables are created automatically on startup. Tests can be executed with:
+
+```bash
+pytest
+```
+
 ### Code Style
 
 We use ESLint and Prettier for code formatting. Run `pnpm lint` to check your code style.

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,7 +16,8 @@ from services import (
     sales_service,
     inventory_service,
     process_service,
-    project_service
+    project_service,
+    dashboard_service,
 )
 from docs import (
     API_TITLE,
@@ -194,6 +195,12 @@ app.include_router(
     project_service.router,
     prefix="/api/projects",
     tags=["Project & Job Management"]
+)
+
+app.include_router(
+    dashboard_service.router,
+    prefix="/api/dashboard",
+    tags=["Business Intelligence"]
 )
 
 # Extension points for future MAS and KG-RAG integration

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -458,3 +458,19 @@ class StandardResponse(BaseModel):
     success: bool
     message: str
     data: Optional[Any] = None
+
+# Dashboard schemas
+class DashboardNotification(BaseModel):
+    id: int
+    message: str
+    date: datetime
+
+
+class DashboardSummary(BaseModel):
+    """Aggregated metrics returned by the dashboard service."""
+
+    financial_kpis: Dict[str, float]
+    active_orders: int
+    low_stock_items: int
+    sales_trend: List[Dict[str, Any]]
+    notifications: List[Dict[str, Any]]

--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -1,0 +1,70 @@
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import List, Dict, Any
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from database import get_db
+import models
+import schemas
+
+router = APIRouter()
+
+@router.get("/summary", response_model=schemas.DashboardSummary)
+def get_dashboard_summary(db: Session = Depends(get_db)) -> schemas.DashboardSummary:
+    """Aggregate metrics for the main dashboard."""
+    # Financial KPIs
+    revenue = (
+        db.query(func.coalesce(func.sum(models.Transaction.amount), 0))
+        .join(models.Account)
+        .filter(models.Transaction.type == "credit", models.Account.type == "revenue")
+        .scalar()
+    )
+    expenses = (
+        db.query(func.coalesce(func.sum(models.Transaction.amount), 0))
+        .join(models.Account)
+        .filter(models.Transaction.type == "debit", models.Account.type == "expense")
+        .scalar()
+    )
+    profit = revenue - expenses
+
+    # Active orders (not cancelled)
+    active_orders = db.query(models.Order).filter(models.Order.status != "cancelled").count()
+
+    # Low stock items
+    low_stock_items = db.query(models.Product).filter(models.Product.stock_quantity <= models.Product.reorder_level).count()
+
+    # Sales trend for last 6 months
+    start_date = datetime.utcnow() - timedelta(days=180)
+    orders = db.query(models.Order).filter(models.Order.order_date >= start_date).all()
+    trend_map: Dict[str, Dict[str, Any]] = defaultdict(lambda: {"month": "", "total_sales": 0.0, "order_count": 0})
+    for order in orders:
+        key = order.order_date.strftime("%Y-%m")
+        bucket = trend_map[key]
+        bucket["month"] = key
+        bucket["total_sales"] += order.total_amount
+        bucket["order_count"] += 1
+    sales_trend = [trend_map[k] for k in sorted(trend_map.keys())]
+
+    # Recent notifications (process events)
+    events = (
+        db.query(models.ProcessEvent)
+        .filter(models.ProcessEvent.status == "pending")
+        .order_by(models.ProcessEvent.created_at.desc())
+        .limit(5)
+        .all()
+    )
+    notifications = [
+        {"id": e.id, "message": e.description, "date": e.created_at} for e in events
+    ]
+
+    return schemas.DashboardSummary(
+        financial_kpis={"total_revenue": revenue, "total_expenses": expenses, "profit_loss": profit},
+        active_orders=active_orders,
+        low_stock_items=low_stock_items,
+        sales_trend=sales_trend,
+        notifications=notifications,
+    )
+

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,14 @@
+import pytest
+from fastapi import status
+
+
+def test_dashboard_summary(client, auth_headers):
+    response = client.get("/api/dashboard/summary", headers=auth_headers)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert "financial_kpis" in data
+    assert "active_orders" in data
+    assert "low_stock_items" in data
+    assert "sales_trend" in data
+    assert "notifications" in data
+


### PR DESCRIPTION
## Summary
- add dashboard_service with KPI aggregation
- expose dashboard routes in FastAPI backend
- document how to run backend and tests
- provide minimal dashboard test

## Testing
- `pytest tests/test_dashboard.py -q`
- `pytest -q` *(fails: 3 failed, 20 passed, 22 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac4334e88322b31dd1f4a5287ad5