### PR TITLE
Fix custom OpenAPI signature

### DIFF
--- a/backend/docs.py
+++ b/backend/docs.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any
+from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 
 # API Documentation Metadata
@@ -100,10 +101,8 @@ API_TAGS_METADATA = [
     }
 ]
 
-def custom_openapi() -> Dict[str, Any]:
-    """
-    Custom OpenAPI schema generator with additional metadata and security schemes
-    """
+def custom_openapi(app: FastAPI) -> Dict[str, Any]:
+    """Generate a custom OpenAPI schema for the provided FastAPI instance."""
     if app.openapi_schema:
         return app.openapi_schema
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -41,7 +41,7 @@ app = FastAPI(
 )
 
 # Set custom OpenAPI schema
-app.openapi = custom_openapi
+app.openapi = lambda: custom_openapi(app)
 
 # CORS middleware
 app.add_middleware(


### PR DESCRIPTION
## Summary
- update OpenAPI helper to accept a FastAPI instance
- assign `app.openapi` using a lambda that calls the helper

## Testing
- `pytest -q`
- `PYTHONPATH=backend python - <<'PY'
from main import app
schema = app.openapi()
print('title:', schema['info']['title'])
print('version:', schema['info']['version'])
print('paths:', len(schema['paths']))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6846b50be5988322a8e862ebf59a4b26