### PR TITLE
Fix CI and add setup script for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,15 +21,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pytest pytest-cov
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt -r backend/requirements-test.txt
     
-    - name: Run tests with coverage
-      run: |
-        pytest --cov=backend tests/
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=backend backend/tests/
     
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
@@ -91,10 +90,10 @@ jobs:
       with:
         python-version: 3.9
     
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
     
     - name: Deploy to production
       run: |

--- a/README.md
+++ b/README.md
@@ -75,13 +75,11 @@ The backend lives in the `backend/` directory. To run it locally with SQLite:
 
 ```bash
 cd backend
-pip install -r requirements.txt
-pip install -r requirements-test.txt
+./setup-tests.sh
 export DATABASE_URL=sqlite:///erp.db  # optional, defaults to this value
 uvicorn main:app --reload
 ```
-
-Both `requirements.txt` and `requirements-test.txt` must be installed before running `pytest`.
+Both `requirements.txt` and `requirements-test.txt` must be installed before running `pytest`. The `setup-tests.sh` script installs them for you.
 
 Tables are created automatically on startup. Tests can be executed with:
 

--- a/backend/setup-tests.sh
+++ b/backend/setup-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Install backend dependencies for development and testing
+pip install -r requirements.txt -r requirements-test.txt


### PR DESCRIPTION
## Summary
- update README with new setup-tests.sh usage
- add setup-tests.sh helper script
- ensure CI installs test requirements and run pytest correctly

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b50db9148322abf8237ee2317737