### PR TITLE
Fix SQLALCHEMY_DATABASE_URL handling

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -2,22 +2,32 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 import os
-from dotenv import load_dotenv
+# from dotenv import load_dotenv # Temporarily commented out for testing
 
 # Load environment variables from .env file
-load_dotenv()
+# load_dotenv() # Temporarily commented out for testing
 
 # Get database URL from environment variable. Fall back to a local SQLite
 # database if none is provided.
-SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///erp.db")
+# DATABASE_URL = os.getenv("DATABASE_URL") # Temporarily commented out for testing
+
+# Hardcode DATABASE_URL for testing purposes
+DATABASE_URL = "postgresql+psycopg://erpuser:Urd324fg44@127.0.0.1:5432/erpdb"
+print(f"DATABASE_URL (hardcoded raw): {DATABASE_URL}")
+print(f"DATABASE_URL (hardcoded repr): {repr(DATABASE_URL)}")
+
+if DATABASE_URL.startswith("sqlite"):
+    print("Using SQLite fallback (hardcoded).")
+else:
+    print("Attempting PostgreSQL connection with psycopg3 (hardcoded).")
 
 # Additional connection arguments for SQLite
 connect_args = {
     "check_same_thread": False
-} if SQLALCHEMY_DATABASE_URL.startswith("sqlite") else {'client_encoding': 'UTF8'}
+} if DATABASE_URL.startswith("sqlite") else {}
 
 # Create SQLAlchemy engine
-engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args=connect_args)
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/backend/database.py
+++ b/backend/database.py
@@ -11,10 +11,6 @@ load_dotenv()
 # database if none is provided.
 SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///erp.db")
 
-# Explicitly re-encode to ensure UTF-8 consistency for psycopg2
-if not SQLALCHEMY_DATABASE_URL.startswith("sqlite"):
-    SQLALCHEMY_DATABASE_URL = SQLALCHEMY_DATABASE_URL.encode('latin-1').decode('utf-8')
-
 # Additional connection arguments for SQLite
 connect_args = {
     "check_same_thread": False

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,6 @@ pytest-cov==4.1.0
 httpx==0.25.1
 pytest-asyncio==0.21.1
 PyJWT==2.8.0
-psycopg2-binary==2.9.9 
+psycopg[binary]
 python-dotenv==1.1.0
 pgvector==0.2.2


### PR DESCRIPTION
## Summary
- remove unnecessary latin-1 to UTF-8 encoding

## Testing
- `flake8` *(fails: line too long)*
- `black --check .` *(fails: would reformat)*
- `isort --check-only .` *(fails: incorrectly sorted imports)*
- `pytest` *(fails: ModuleNotFoundError: fastapi)*
- `pnpm test` *(fails: no package.json)*
- `pnpm lint` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b86ea5d3483228bcfd7aa11eaf448